### PR TITLE
Fix USB midi communication

### DIFF
--- a/ds/libdsmi/source/libdsmi.c
+++ b/ds/libdsmi/source/libdsmi.c
@@ -404,9 +404,9 @@ int dsmi_read_usb(u8* message, u8* data1, u8* data2)
 
 	tud_midi_packet_read(recbuf);
 
-	*message = recbuf[0];
-	*data1 = recbuf[1];
-	*data2 = recbuf[2];
+	*message = recbuf[1];
+	*data1 = recbuf[2];
+	*data2 = recbuf[3];
 
 	return 1;
 }

--- a/ds/libdsmi/source/usb_descriptors.c
+++ b/ds/libdsmi/source/usb_descriptors.c
@@ -78,7 +78,7 @@ uint8_t const * tud_descriptor_device_cb(void)
 enum
 {
   ITF_NUM_MIDI = 0,
-  ITF_NUM_TOTAL
+  ITF_NUM_TOTAL = 2
 };
 
 #define CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_MIDI_DESC_LEN)


### PR DESCRIPTION
Bugfixes - The device descriptor was incomplete and the midi packet reading wasn't working over USB. 